### PR TITLE
feat: On-Demand Revalidation APIを追加してキャッシュ無効化を可能に

### DIFF
--- a/apps/web/app/api/revalidate/route.ts
+++ b/apps/web/app/api/revalidate/route.ts
@@ -1,0 +1,52 @@
+import { revalidateTag, revalidatePath } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * On-Demand Revalidation API ルート
+ * 
+ * データ更新時にキャッシュを無効化するためのエンドポイント
+ * [02 設計資料](../../../docs/02-design.md) 2.3節、[04 開発ガイド](../../../docs/04-development.md) 9節参照
+ * 
+ * 使用方法:
+ * - POST /api/revalidate?tag=facilities
+ * - POST /api/revalidate?tag=schedules
+ * - POST /api/revalidate?path=/
+ * 
+ * セキュリティ:
+ * - 本番環境では、認証トークンやシークレットの検証を追加すること
+ * - 例: Authorization ヘッダーでトークンを検証
+ */
+export async function POST(request: NextRequest) {
+	const searchParams = request.nextUrl.searchParams;
+	const tag = searchParams.get('tag');
+	const path = searchParams.get('path');
+
+	// セキュリティチェック: 本番環境では認証を追加すること
+	// const authHeader = request.headers.get('authorization');
+	// if (authHeader !== `Bearer ${process.env.REVALIDATE_SECRET}`) {
+	//   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+	// }
+
+	if (tag) {
+		revalidateTag(tag);
+		return NextResponse.json({
+			revalidated: true,
+			tag,
+			now: Date.now(),
+		});
+	}
+
+	if (path) {
+		revalidatePath(path);
+		return NextResponse.json({
+			revalidated: true,
+			path,
+			now: Date.now(),
+		});
+	}
+
+	return NextResponse.json(
+		{ error: 'Missing tag or path parameter' },
+		{ status: 400 }
+	);
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -14,6 +14,7 @@ import type { Facility, FacilitiesByWard } from '../lib/types';
  * [04 開発ガイド](../docs/04-development.md) 5.7節を参照
  * 
  * ISR: 60分間キャッシュ（[02 設計資料](../docs/02-design.md) 2.3節参照）
+ * データ更新時は `/api/revalidate?tag=facilities` を呼び出すことでキャッシュを無効化できる。
  * 
  * お気に入りはlocalStorageに保存されるため、サーバー側では初期値として空配列を渡す。
  * クライアント側で useEffect により読み込まれる。

--- a/apps/web/lib/facilities.ts
+++ b/apps/web/lib/facilities.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase';
 import type { Facility } from './types';
 import { createSupabaseErrorMessage } from './supabase-errors';
+import { unstable_cache } from 'next/cache';
 
 /**
  * 施設データ取得時に選択するフィールド（共通定義）
@@ -9,10 +10,10 @@ import { createSupabaseErrorMessage } from './supabase-errors';
 const FACILITY_FIELDS_FOR_LIST = 'id,name,ward_name,address_full_raw,phone,instagram_url,website_url,facility_type,detail_page_url';
 
 /**
- * Supabase から拠点一覧を取得する
+ * Supabase から拠点一覧を取得する（内部実装）
  * [03 API 仕様](../docs/03-api.md) 2.2.1節を参照
  */
-export async function getFacilities(): Promise<Facility[]> {
+async function getFacilitiesInternal(): Promise<Facility[]> {
 	const { data, error } = await supabase
 		.from('facilities')
 		.select(FACILITY_FIELDS_FOR_LIST)
@@ -25,6 +26,21 @@ export async function getFacilities(): Promise<Facility[]> {
 
 	return data || [];
 }
+
+/**
+ * Supabase から拠点一覧を取得する（キャッシュ付き）
+ * ISR により60分間キャッシュされる。On-Demand Revalidation で `revalidateTag('facilities')` を呼び出すことで
+ * キャッシュを無効化できる。
+ * [02 設計資料](../docs/02-design.md) 2.3節参照
+ */
+export const getFacilities = unstable_cache(
+	async () => getFacilitiesInternal(),
+	['facilities'],
+	{
+		tags: ['facilities'],
+		revalidate: 3600, // 60分
+	}
+);
 
 /**
  * IDで拠点を1件取得する


### PR DESCRIPTION
## 概要

このPRでは、データベース更新後にNext.jsのISRキャッシュを即座に無効化できるOn-Demand Revalidation APIを実装しました。これにより、施設データを削除・更新した際に、アプリケーションのキャッシュを手動で無効化できるようになります。

## 変更内容

- `/api/revalidate` エンドポイントを追加し、`tag` または `path` パラメータでキャッシュを無効化可能に
- `getFacilities` 関数に `unstable_cache` を使用して `facilities` タグを付与
- データ更新時に `revalidateTag('facilities')` を呼び出すことで即座にキャッシュを無効化可能
- 設計資料に記載されていたOn-Demand Revalidation機能を実装

## 技術的な詳細

- Next.js 14 の `unstable_cache` と `revalidateTag` を使用
- ISR（Incremental Static Regeneration）の60分キャッシュを維持しつつ、必要に応じて手動で無効化可能
- `apps/web/app/api/revalidate/route.ts` に新しいAPIルートを実装
- `apps/web/lib/facilities.ts` の `getFacilities` 関数を `unstable_cache` でラップし、キャッシュタグを付与

## テスト内容

- ローカルでの動作確認（型チェック、Lint チェック）
- curl での API エンドポイント呼び出しテスト（デプロイ後の確認が必要）
- デプロイ後、`curl -X POST "https://childcare-schedule-hub-web.vercel.app/api/revalidate?tag=facilities"` でキャッシュ無効化を確認予定

**注意**: 現在の実装では認証が未設定のため、本番環境ではセキュリティトークンの検証を追加する必要があります（コメント内に例を記載済み）。

## 関連Issue

データベースから施設を削除した際に、Vercelでデプロイされたアプリケーションで古いキャッシュが残る問題を解決するために実装しました。